### PR TITLE
added playlist_only, apple_music & protected tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ movement_number = None (Integer)
 movement_count = None (Integer)
 loved = False (Boolean)
 album_loved = False (Boolean)
+playlist_only = None (Bool)
+apple_music = None (Bool)
+protected = None (Bool)
 
 ```
 

--- a/libpytunes/Library.py
+++ b/libpytunes/Library.py
@@ -34,10 +34,6 @@ class Library:
         for trackid, attributes in self.il['Tracks'].items():
             s = Song()
 
-            # Naive check for TV Shows, Movies, and Podcasts
-            if 'Series' in attributes or 'Movie' in attributes or 'Podcast' in attributes:
-                continue
-
             s.name = attributes.get('Name')
 
             # Support classical music naming (Work+Movement Number+Movement Name) since iTunes 12.5

--- a/libpytunes/Library.py
+++ b/libpytunes/Library.py
@@ -34,7 +34,7 @@ class Library:
         for trackid, attributes in self.il['Tracks'].items():
             s = Song()
 
-            # Naïve check for TV Shows, Movies, and Podcasts
+            # Naive check for TV Shows, Movies, and Podcasts
             if 'Series' in attributes or 'Movie' in attributes or 'Podcast' in attributes:
                 continue
 

--- a/libpytunes/Library.py
+++ b/libpytunes/Library.py
@@ -33,6 +33,11 @@ class Library:
         format = "%Y-%m-%d %H:%M:%S"
         for trackid, attributes in self.il['Tracks'].items():
             s = Song()
+
+            # Naïve check for TV Shows, Movies, and Podcasts
+            if 'Series' in attributes or 'Movie' in attributes or 'Podcast' in attributes:
+                continue
+
             s.name = attributes.get('Name')
 
             # Support classical music naming (Work+Movement Number+Movement Name) since iTunes 12.5
@@ -87,6 +92,9 @@ class Library:
             s.has_video = 'Has Video' in attributes
             s.loved = 'Loved' in attributes
             s.album_loved = 'Album Loved' in attributes
+            s.playlist_only = 'Playlist Only' in attributes
+            s.apple_music = 'Apple Music' in attributes
+            s.protected = 'Protected' in attributes
 
             self.songs[int(trackid)] = s
 

--- a/libpytunes/Song.py
+++ b/libpytunes/Song.py
@@ -42,6 +42,9 @@ class Song:
     movement_name = None (String)
     movement_number = None (Integer)
     movement_count = None (Integer)
+    playlist_only = None (Bool)
+    apple_music = None (Bool)
+    protected = None (Bool)
     """
     name = None
     track_id = None
@@ -81,6 +84,9 @@ class Song:
     movement_name = None
     movement_number = None
     movement_count = None
+    playlist_only = None
+    apple_music = None
+    protected = None
 
     def __iter__(self):
         for attr, value in iteritems(self.__dict__):


### PR DESCRIPTION
Added parsing for three attributes that do the following:

1. `playlist_only`: Songs that are in playlists of the user but not in their library have a value of `true` for this attribute. 

- Filter out only the songs from a person's library and exclude playlist songs. This is helpful especially when `Add songs to library when adding to playlists` is unchecked in iTunes preferences.

2. `apple_music`: Songs that are from Apple Music (not manually uploaded to iCloud Music Library) have a `true` value for this attribute. 

- Helpful to distinguish between manually uploaded tracks vs tracks added from Apple Music

3. `protected`: DRM protected songs have a `true` value for this attribute.

- Helpful to check DRM status of songs

Further a Naïve check has been implemented to exclude Movies, TV Shows and Podcasts from parsing by checking if they have a corresponding attribute.